### PR TITLE
Show binary strings with content separated from header

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,8 +72,12 @@
 				};
 			} else if (majorType.type === 2) {
 				annotate(null, 'byte sequence (length ' + majorType.value + ')');
+				indent(1, pos)
 				// Byte sequence
 				var length = majorType.value;
+				var byteHex = hex.substring(pos, pos + length*2);
+				annotate(pos, 'binary');
+				indent(-1, pos+length*2);
 				return {
 					value: hex.substring(pos, pos + length*2),
 					nextPos: pos + length*2


### PR DESCRIPTION
This fixes #2 but would be nicer if it was not indented but just with a space.